### PR TITLE
数据连接传到后端连接的前8个字节为标识位。解决TunnelClient代码逻辑上丢失后面字节的bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>top.meethigher</groupId>
     <artifactId>tcp-reverse-proxy</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>

--- a/src/main/java/top/meethigher/proxy/tcp/tunnel/ReverseTcpProxyTunnelServer.java
+++ b/src/main/java/top/meethigher/proxy/tcp/tunnel/ReverseTcpProxyTunnelServer.java
@@ -335,7 +335,11 @@ public class ReverseTcpProxyTunnelServer extends TunnelServer {
                     .appendBytes(DATA_CONN_FLAG)
                     .appendInt(sessionId)).onSuccess(v -> {
                 // 将用户连接中的缓存数据发出。
-                userConn.buffers.forEach(dataSocket::write);
+                userConn.buffers.forEach(b -> dataSocket.write(b)
+                        .onSuccess(o -> log.debug("{}: sessionId {}, user connection {} -- {} write to data connection {} -- {} succeeded",
+                                name,
+                                sessionId,
+                                userSocket.remoteAddress(), userSocket.localAddress(), dataSocket.remoteAddress(), dataSocket.localAddress())));
             });
 
         }

--- a/src/main/java/top/meethigher/proxy/tcp/tunnel/ReverseTcpProxyTunnelServer.java
+++ b/src/main/java/top/meethigher/proxy/tcp/tunnel/ReverseTcpProxyTunnelServer.java
@@ -301,25 +301,29 @@ public class ReverseTcpProxyTunnelServer extends TunnelServer {
             // 双向生命周期绑定、双向数据转发
             // feat: v1.0.5以前的版本，在closeHandler里面，将对端连接也关闭。比如targetSocket关闭时，则将sourceSocket也关闭。
             // 结果导致在转发短连接时，出现了bug。参考https://github.com/meethigher/tcp-reverse-proxy/issues/6
-            userSocket.closeHandler(v -> {
-                log.debug("{}: sessionId {}, user connection {} -- {} closed", name, sessionId, userSocket.remoteAddress(), userSocket.localAddress());
-            }).pipeTo(dataSocket).onFailure(e -> {
-                log.error("{}: sessionId {}, user connection {} -- {} pipe to data connection {} -- {} failed, connection will be closed",
-                        name,
-                        sessionId,
-                        userSocket.remoteAddress(), userSocket.localAddress(), dataSocket.remoteAddress(), dataSocket.localAddress(), e);
-            });
-            dataSocket.closeHandler(v -> {
-                log.debug("{}: sessionId {}, data connection {} -- {} closed",
-                        name,
-                        sessionId,
-                        dataSocket.remoteAddress(), dataSocket.localAddress());
-            }).pipeTo(userSocket).onFailure(e -> {
-                log.error("{}: sessionId {}, data connection {} -- {} pipe to user connection {} -- {} failed, connection will be closed",
-                        name,
-                        sessionId,
-                        dataSocket.remoteAddress(), dataSocket.localAddress(), userSocket.remoteAddress(), userSocket.localAddress(), e);
-            });
+            userSocket.closeHandler(v -> log.debug("{}: sessionId {}, user connection {} -- {} closed", name, sessionId, userSocket.remoteAddress(), userSocket.localAddress()))
+                    .pipeTo(dataSocket)
+                    .onFailure(e -> log.error("{}: sessionId {}, user connection {} -- {} pipe to data connection {} -- {} failed",
+                            name,
+                            sessionId,
+                            userSocket.remoteAddress(), userSocket.localAddress(), dataSocket.remoteAddress(), dataSocket.localAddress(), e))
+                    .onSuccess(v -> log.debug("{}: sessionId {}, user connection {} -- {} pipe to data connection {} -- {} succeeded",
+                            name,
+                            sessionId,
+                            userSocket.remoteAddress(), userSocket.localAddress(), dataSocket.remoteAddress(), dataSocket.localAddress()));
+            dataSocket.closeHandler(v -> log.debug("{}: sessionId {}, data connection {} -- {} closed",
+                            name,
+                            sessionId,
+                            dataSocket.remoteAddress(), dataSocket.localAddress()))
+                    .pipeTo(userSocket)
+                    .onFailure(e -> log.error("{}: sessionId {}, data connection {} -- {} pipe to user connection {} -- {} failed",
+                            name,
+                            sessionId,
+                            dataSocket.remoteAddress(), dataSocket.localAddress(), userSocket.remoteAddress(), userSocket.localAddress(), e))
+                    .onSuccess(v -> log.debug("{}: sessionId {}, data connection {} -- {} pipe to user connection {} -- {} succeeded",
+                            name,
+                            sessionId,
+                            dataSocket.remoteAddress(), dataSocket.localAddress(), userSocket.remoteAddress(), userSocket.localAddress()));
             log.debug("{}: sessionId {}, data connection {} -- {} bound to user connection {} -- {} for session id {}",
                     name,
                     sessionId,

--- a/src/main/java/top/meethigher/proxy/tcp/tunnel/ReverseTcpProxyTunnelServer.java
+++ b/src/main/java/top/meethigher/proxy/tcp/tunnel/ReverseTcpProxyTunnelServer.java
@@ -94,7 +94,7 @@ public class ReverseTcpProxyTunnelServer extends TunnelServer {
         socket.pause();
         socket.handler(decode(socket));
         socket.closeHandler(v -> {
-            log.debug("closed {} -- {}", socket.remoteAddress(), socket.localAddress());
+            log.debug("{} -- {} closed", socket.remoteAddress(), socket.localAddress());
             DataProxyServer removed = authedSockets.remove(socket);
             if (removed != null) {
                 removed.stop();
@@ -410,7 +410,7 @@ public class ReverseTcpProxyTunnelServer extends TunnelServer {
      */
     protected void addMessageHandler() {
         // 监听连接成功事件
-        this.onConnected((vertx1, netSocket, buffer) -> log.debug("{} connected", netSocket.remoteAddress()));
+        this.onConnected((vertx1, netSocket, buffer) -> log.debug("{} -- {} connected", netSocket.remoteAddress(), netSocket.localAddress()));
 
         // 监听心跳事件
         this.on(TunnelMessageType.HEARTBEAT, new AbstractTunnelHandler() {

--- a/src/test/java/top/meethigher/proxy/tcp/tunnel/Issue9Test.java
+++ b/src/test/java/top/meethigher/proxy/tcp/tunnel/Issue9Test.java
@@ -1,0 +1,67 @@
+package top.meethigher.proxy.tcp.tunnel;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.PoolOptions;
+import io.vertx.core.http.RequestOptions;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class Issue9Test {
+    private static final Logger log = LoggerFactory.getLogger(Issue9Test.class);
+
+    @Test
+    public void test() throws Exception {
+
+        /**
+         * IDEA 多配置“批量启动”——使用 Run/Debug Configuration 的“Compound”功能
+         * 步骤如下：
+         * 打开Run/Debug Configurations窗口（快捷键 Ctrl+Alt+R / 右上角 Edit Configurations）。
+         *
+         * 新建三个 Application 类型配置，分别设置好 ClassA、ClassB、ClassC 的 main。
+         *
+         * 再新建一个Compound类型配置。
+         *
+         * 在 Compound 配置的“Run/Debug Configurations”里，添加刚刚那三个配置，顺序拖拽即可调整。
+         *
+         * 选中 Compound 配置，点绿色启动按钮，一次性批量顺序启动三（或更多）个实例。
+         *
+         * 注意：Compound 是并发同时，不是顺序启动。IDEA 会按照你添加的顺序一个一个起。
+         */
+
+        // step1: run top.meethigher.proxy.tcp.tunnel.issue9.Issue9SimpleHttpServer.main
+
+        // step2: run top.meethigher.proxy.tcp.tunnel.issue9.Issue9TunnelServer.main
+
+        // step3: run top.meethigher.proxy.tcp.tunnel.issue9.Issue9TunnelClient.main
+
+        Vertx vertx = Vertx.vertx();
+        HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions()
+                        .setKeepAlive(true)
+                        .setMaxPoolSize(Runtime.getRuntime().availableProcessors()),
+                new PoolOptions().setHttp1MaxSize(100));
+        int total = 500;
+        CountDownLatch latch = new CountDownLatch(total);
+        for (int i = 0; i < total; i++) {
+            final String id = String.valueOf(i + 1);
+            RequestOptions requestOptions = new RequestOptions()
+                    .setAbsoluteURI("http://127.0.0.1:808/api");
+            httpClient.request(requestOptions).onSuccess(req -> {
+                req.send().onSuccess(resp -> {
+                    log.info("{} succeeded", id);
+                    latch.countDown();
+                });
+            });
+        }
+
+        latch.await(5, TimeUnit.SECONDS);
+        Assert.assertEquals(total, total - latch.getCount());
+
+    }
+}

--- a/src/test/java/top/meethigher/proxy/tcp/tunnel/issue9/Issue9SimpleHttpServer.java
+++ b/src/test/java/top/meethigher/proxy/tcp/tunnel/issue9/Issue9SimpleHttpServer.java
@@ -1,0 +1,37 @@
+package top.meethigher.proxy.tcp.tunnel.issue9;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Issue9SimpleHttpServer {
+
+    private static final Logger log = LoggerFactory.getLogger(Issue9SimpleHttpServer.class);
+    private static final Vertx vertx = Vertx.vertx();
+
+    public static void main(String[] args) {
+        final String result = "<!DOCTYPE html><html><head><meta charset=utf-8><meta name=viewport content=\"width=device-width,initial-scale=1\"><title>novnc2</title><link href=./static/css/app.c90a3de1d5a865cd4149616f9b8040a5.css rel=stylesheet></head><body><div id=app></div><script type=text/javascript src=./static/js/manifest.3ad1d5771e9b13dbdad2.js></script><script type=text/javascript src=./static/js/vendor.eba9acff8b0b3b1b22c4.js></script><script type=text/javascript src=./static/js/app.fef011cae8f5fbff4b55.js></script></body></html>";
+        HttpServer httpServer = vertx.createHttpServer();
+        httpServer.requestHandler(req -> {
+            String address = req.connection().remoteAddress().toString();
+            log.info("{} connected", address);
+            req.connection().closeHandler(v -> {
+                log.info("{} closed", address);
+            });
+            HttpServerResponse response = req.response();
+            response.putHeader("Server", "nginx/1.18.0 (Ubuntu)");
+            response.putHeader("Date", "Mon, 02 Jun 2025 07:22:44 GMT");
+            response.putHeader("Content-Type", "text/html");
+            response.putHeader("Content-Length", "512");
+            response.putHeader("Last-Modified", "Sun, 04 Apr 2021 03:44:30 GMT");
+            response.putHeader("ETag", "\"6069361e-200\"");
+            response.putHeader("Accept-Ranges", "bytes");
+            response.setStatusCode(200).end(result);
+        }).listen(80).onFailure(e -> {
+            log.error("http server start failed", e);
+            System.exit(1);
+        });
+    }
+}

--- a/src/test/java/top/meethigher/proxy/tcp/tunnel/issue9/Issue9TunnelClient.java
+++ b/src/test/java/top/meethigher/proxy/tcp/tunnel/issue9/Issue9TunnelClient.java
@@ -1,0 +1,29 @@
+package top.meethigher.proxy.tcp.tunnel.issue9;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetClientOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import top.meethigher.proxy.tcp.tunnel.ReverseTcpProxyTunnelClient;
+
+import java.util.concurrent.TimeUnit;
+
+public class Issue9TunnelClient {
+
+    private static final Vertx vertx = Vertx.vertx();
+    private static final Logger log = LoggerFactory.getLogger(Issue9TunnelClient.class);
+
+    public static void main(String[] args) {
+        NetClient netClient = vertx.createNetClient(new NetClientOptions()
+                .setIdleTimeout(999999999)
+                .setIdleTimeoutUnit(TimeUnit.MILLISECONDS));
+        ReverseTcpProxyTunnelClient.create(vertx, netClient)
+                .dataProxyPort(808)
+                .dataProxyHost("127.0.0.1")
+                .dataProxyName("http")
+                .backendHost("127.0.0.1")
+                .backendPort(80)
+                .connect("127.0.0.1", 44444);
+    }
+}

--- a/src/test/java/top/meethigher/proxy/tcp/tunnel/issue9/Issue9TunnelServer.java
+++ b/src/test/java/top/meethigher/proxy/tcp/tunnel/issue9/Issue9TunnelServer.java
@@ -1,0 +1,28 @@
+package top.meethigher.proxy.tcp.tunnel.issue9;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import top.meethigher.proxy.tcp.tunnel.ReverseTcpProxyTunnelServer;
+
+import java.util.concurrent.TimeUnit;
+
+public class Issue9TunnelServer {
+
+    private static final Vertx vertx = Vertx.vertx();
+    private static final Logger log = LoggerFactory.getLogger(Issue9TunnelServer.class);
+
+    public static void main(String[] args) {
+        NetServer netServer = vertx.createNetServer(
+                new NetServerOptions()
+                        .setIdleTimeout(999999999)
+                        .setIdleTimeoutUnit(TimeUnit.MILLISECONDS));
+        ReverseTcpProxyTunnelServer.create(vertx, netServer)
+                .heartbeatDelay(888888888)
+                .judgeDelay(50)
+                .port(44444)
+                .start();
+    }
+}


### PR DESCRIPTION
数据连接传到后端连接的前8个字节为标识位。解决TunnelClient代码逻辑上丢失后面字节的bug

https://github.com/meethigher/tcp-reverse-proxy/issues/9